### PR TITLE
Fix websocket reconnection logic

### DIFF
--- a/cbadv/websocket_client.py
+++ b/cbadv/websocket_client.py
@@ -88,6 +88,7 @@ class WebsocketClient(object):
                 self.on_error(e)
             except Exception as e:
                 self.on_error(e)
+                self._reconnect()
             else:
                 self.on_message(msg)
 
@@ -102,6 +103,12 @@ class WebsocketClient(object):
 
         self.on_close()
 
+    def _reconnect(self):
+        self._disconnect()
+        time.sleep(0.01)  # Wait for 0.01 seconds before reconnecting
+        self._connect()
+        self._listen()
+
     def close(self):
         self.stop = True   # will only disconnect after next msg recv
         self._disconnect() # force disconnect so threads can join
@@ -114,6 +121,7 @@ class WebsocketClient(object):
     def on_close(self):
         if self.should_print:
             print("\n-- Socket Closed --")
+        self._reconnect()
 
     def on_message(self, msg):
         if self.should_print:

--- a/tests/test_websocket_client.py
+++ b/tests/test_websocket_client.py
@@ -1,0 +1,50 @@
+import unittest
+from unittest.mock import patch, MagicMock
+from cbadv.websocket_client import WebsocketClient
+
+class TestWebsocketClient(unittest.TestCase):
+
+    @patch('cbadv.websocket_client.create_connection')
+    def setUp(self, mock_create_connection):
+        self.api_key = 'test_api_key'
+        self.api_secret = 'test_api_secret'
+        self.client = WebsocketClient(api_key=self.api_key, api_secret=self.api_secret, channel='ticker')
+        self.client.ws = MagicMock()
+
+    @patch('cbadv.websocket_client.create_connection')
+    def test_reconnect(self, mock_create_connection):
+        self.client._reconnect()
+        self.assertTrue(self.client.ws.close.called)
+        self.assertTrue(mock_create_connection.called)
+
+    @patch('cbadv.websocket_client.create_connection')
+    def test_listen_reconnect_on_error(self, mock_create_connection):
+        self.client.ws.recv.side_effect = Exception("Connection drop")
+        with patch.object(self.client, '_reconnect') as mock_reconnect:
+            self.client._listen()
+            self.assertTrue(mock_reconnect.called)
+
+    @patch('cbadv.websocket_client.create_connection')
+    def test_on_close_reconnect(self, mock_create_connection):
+        with patch.object(self.client, '_reconnect') as mock_reconnect:
+            self.client.on_close()
+            self.assertTrue(mock_reconnect.called)
+
+    @patch('cbadv.websocket_client.create_connection')
+    def test_simulate_connection_drop(self, mock_create_connection):
+        self.client.ws.recv.side_effect = Exception("Connection drop")
+        with patch.object(self.client, '_reconnect') as mock_reconnect:
+            self.client._listen()
+            self.assertTrue(mock_reconnect.called)
+
+    @patch('cbadv.websocket_client.create_connection')
+    def test_verify_reconnect_method(self, mock_create_connection):
+        with patch.object(self.client, '_disconnect') as mock_disconnect:
+            with patch.object(self.client, '_connect') as mock_connect:
+                with patch('time.sleep', return_value=None):
+                    self.client._reconnect()
+                    self.assertTrue(mock_disconnect.called)
+                    self.assertTrue(mock_connect.called)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes #1

Implement reconnection logic for websocket connection in case of connection drop.

* **cbadv/websocket_client.py**
  - Add `_reconnect` method to handle reconnection attempts.
  - Modify `_listen` method to call `_reconnect` on connection drop.
  - Update `on_close` method to call `_reconnect`.

* **tests/test_websocket_client.py**
  - Create new test file for `WebsocketClient` reconnection logic.
  - Add test to simulate a connection drop and verify reconnection.
  - Add test to verify `_reconnect` method behavior.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kkuette/coinbaseadv-python/pull/2?shareId=c24829d1-c9c6-482b-a5b3-809cfffbd42c).